### PR TITLE
fix: save package in devDependencies

### DIFF
--- a/command-builder/package.json
+++ b/command-builder/package.json
@@ -5,6 +5,9 @@
   "main": "index.js",
   "builders": "./builders.json",
   "schematics": "./collection.json",
+  "ng-add": {
+    "save": "devDependencies"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/santoshyadav198613/netlify-builder.git"


### PR DESCRIPTION
In the latest versions of the CLI `ng-add` packages can be added to `devDependencies` and this package is perfect for such use case since it's only needed for development.

See: https://github.com/angular/angular-cli/pull/15815