### PR TITLE
Remove unnecessary call of  `addPackageJsonDependencies()`

### DIFF
--- a/command-builder/ng-add/index.ts
+++ b/command-builder/ng-add/index.ts
@@ -108,7 +108,7 @@ export function netlifyBuilder(options: NgAddOptions): Rule {
                 "siteId": options.siteID,
             }
         }
-        addPackageJsonDependencies();
+        
         tree.overwrite(workspacePath, JSON.stringify(workspace, null, 2));
 
         return tree;


### PR DESCRIPTION
IMHO the call of ` addPackageJsonDependencies()` on line 111 was not necessary as it returned a rule that was never called.