### PR TITLE
Correct id to $id for angular 12 update

### DIFF
--- a/src/deploy/schema.json
+++ b/src/deploy/schema.json
@@ -1,5 +1,5 @@
 {
-  "id": "Schema",
+  "$id": "Schema",
   "title": "schema",
   "description": "Deployment of Angular CLI applications to Netlify",
   "properties": {


### PR DESCRIPTION
Angular 12 when got warning: "Schema" schema is using the keyword "id" which its support is deprecated. Use "$id" for schema ID.