### PR TITLE
Removed "addPackageJsonDependencies" as it is not required as we have "ng-add" in package.json file

### DIFF
--- a/src/ng-add/index.ts
+++ b/src/ng-add/index.ts
@@ -1,24 +1,6 @@
 import { Rule, SchematicContext, SchematicsException, Tree, chain } from '@angular-devkit/schematics';
 import {  JsonParseMode, parseJson } from '@angular-devkit/core';
-import { addPackageJsonDependency, NodeDependency, NodeDependencyType } from 'schematics-utilities';
 import { Workspace } from '../interfaces';
-
-function addPackageJsonDependencies(): Rule {
-    return (host: Tree, context: SchematicContext) => {
-
-        // always add the package under dev dependencies
-        const dependencies: NodeDependency[] = [
-            { type: NodeDependencyType.Dev, version: '~3.1.0', name: '@netlify-builder/deploy' }
-        ];
-
-        dependencies.forEach(dependency => {
-            addPackageJsonDependency(host, dependency);
-            context.logger.log('info', `✅️ Added "${dependency.name}" into ${dependency.type}`);
-        });
-
-        return host;
-    };
-}
 
 function getWorkspace(host: Tree): { path: string; workspace: Workspace } {
     const possibleFiles = ['/angular.json', './angular.json'];
@@ -108,6 +90,5 @@ export function netlifyBuilder(options: NgAddOptions): Rule {
 export default function (options: NgAddOptions): Rule {
     return chain([
         netlifyBuilder(options),
-        addPackageJsonDependencies()
     ]);
 }

--- a/src/ng-add/schema.json
+++ b/src/ng-add/schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/schema",
-    "id": "netlify-builder-deploy-ng-add",
+    "$id": "netlify-builder-deploy-ng-add",
     "title": "Netlify Builder ng-add schematic",
     "type": "object",
     "properties": {

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@netlify-builder/deploy",
-    "version": "4.0.0",
+    "version": "4.1.0",
     "description": "A Netlify builder schematics for deployment",
     "main": "index.js",
     "builders": "./builders.json",
@@ -49,7 +49,7 @@
     "dependencies": {
         "@angular-devkit/architect": "^0.1200.0",
         "@angular-devkit/core": "^12.0.0",
-        "schematics-utilities": "^2.0.2",
+        "@angular-devkit/schematics": "^12.0.0",
         "netlify": "^6.1.1"
     }
 }


### PR DESCRIPTION
- Removed "addPackageJsonDependencies" as it is not required as we have "ng-add" in package.json file

- Schema  "id" support is deprecated. Used "$id" for schema ID.

- Removed package "schematics-utilities" as it was not maintained with latest angular version and replace it with angular schematics.
