### PR TITLE
Revert "fix(deps): update dependency netlify to v7"

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -50,6 +50,6 @@
         "@angular-devkit/architect": "^0.1200.0",
         "@angular-devkit/core": "^12.0.0",
         "@angular-devkit/schematics": "^12.0.0",
-        "netlify": "^7.0.0"
+        "netlify": "^6.1.1"
     }
 }


### PR DESCRIPTION
Version 7 had deployment removed in favour of CLI deployment. Can take a look at that soon, but I think this needs reverting and patching as latest doesn't work

Reverts ngx-builders/netlify-builder#129