### PR TITLE
added github action to publish package to npm

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,37 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
+
+name: Node.js Package
+
+on:
+    push:
+        branches:
+            - 'release/**'
+    release:
+        types: [created]
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/setup-node@v2
+              with:
+                  node-version: 12
+            - run: npm install
+
+    publish-npm:
+        needs: build
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/setup-node@v2
+              with:
+                  node-version: 12
+                  registry-url: https://registry.npmjs.org/
+                  scope: '@ngx-builders'
+            - run: npm install
+            - run: npm publish
+              env:
+                  NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@netlify-builder/deploy",
-    "version": "4.1.2",
+    "version": "4.1.3",
     "description": "A Netlify builder schematics for deployment",
     "main": "index.js",
     "builders": "./builders.json",


### PR DESCRIPTION
To publish package to npm, we need to create a new release branch which will trigger the github action.
branch name convention:- release/<version-number>